### PR TITLE
Removed AT in favor of Reflection

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,8 +80,6 @@ processResources
     from(sourceSets.main.resources.srcDirs) {
         exclude 'mcmod.info'
     }
-
-    rename '(.+_at.cfg)', 'META-INF/$1'
 }
 
 task deobfJar(type: Jar) {
@@ -91,12 +89,4 @@ task deobfJar(type: Jar) {
 
 artifacts {
     archives deobfJar
-}
-
-jar {
-
-    manifest {
-
-        attributes 'FMLAT': '${config.mod_id}_at.cfg'
-    }
 }

--- a/build.properties
+++ b/build.properties
@@ -3,6 +3,6 @@
 mcp_mappings=snapshot_20171003
 minecraft_version=1.12.2
 forge_version=14.23.3.2655
-mod_version=1.2.0
+mod_version=1.2.1
 group_name=ttftcuts.chickenshades
 mod_id=chickenshades

--- a/src/main/resources/chickenshades_at.cfg
+++ b/src/main/resources/chickenshades_at.cfg
@@ -1,1 +1,0 @@
-public net.minecraft.client.renderer.entity.RenderLivingBase field_177097_h # layerRenderers


### PR DESCRIPTION
Removed the AccessTransformer used for removing added LayerRenders and replaced with Reflection.

This is run infrequently enough, you have to load a ResourcePack or purposely hit F3+T that an AT was slightly overkill and any performance losses due to Reflection aren't noticable.

Reflection has the benefit of being the way the Forge Team prefers people to handle the situation where you need to modify a value like this.

Removed unused Imports